### PR TITLE
Pass config through to launchBuilder()

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function SiteBuilderOptions(info, config, repoDir, destDir) {
 
 function makeBuilderListener(webhook, config, builderConfig) {
   webhook.on('refs/heads/' + builderConfig.branch, function(info) {
-    siteBuilder.launchBuilder(info, new SiteBuilderOptions(info, config,
+    siteBuilder.launchBuilder(info, config, new SiteBuilderOptions(info, config,
       builderConfig.repositoryDir, builderConfig.generatedSiteDir));
   });
 }

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -234,7 +234,7 @@ SiteBuilder.prototype.jekyllBuild = function() {
   return this.spawn(jekyll, args);
 };
 
-exports.launchBuilder = function (info, builderOpts) {
+exports.launchBuilder = function (info, config, builderOpts) {
   var commit = info.head_commit;  // jshint ignore:line
   var buildLog = builderOpts.sitePath + '.log';
   var logger = new buildLogger.BuildLogger(buildLog);


### PR DESCRIPTION
Gonna merge this and cut v0.0.2. This time actually checked it on the server first, to make sure it worked when refiring a webhook. After this change and the new version, the server will be running from the npm, not from the server's clone of the 18F/pages repo.

My next PR will be to add some tests for this and factor out a bunch of redundant configuration getting passed around.
