### PR TITLE
Don't copy dotfiles and git repos during rsync

### DIFF
--- a/pages-config.json
+++ b/pages-config.json
@@ -5,7 +5,9 @@
   "bundler":          "/usr/local/rbenv/shims/bundle",
   "jekyll":           "/usr/local/rbenv/shims/jekyll",
   "rsync":            "/usr/bin/rsync",
-  "rsyncOpts":        ["-vaxp", "--delete", "--ignore-errors"],
+  "rsyncOpts":        [
+    "-vaxp", "--delete", "--ignore-errors", "--exclude=.[A-Za-z0-9]*"
+  ],
   "payloadLimit":     1048576,
   "githubOrg":        "18F",
   "pagesConfig":      "_config_18f_pages.yml",

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -377,7 +377,8 @@ describe('SiteBuilder', function() {
             expect(spawnCalls()).to.eql([
               'git stash',
               'git pull',
-              'rsync -vaxp --delete --ignore-errors ./ dest_dir/repo_name',
+              'rsync -vaxp --delete --ignore-errors --exclude=.[A-Za-z0-9]* ' +
+                './ dest_dir/repo_name',
             ]);
             logMock.verify();
           }));


### PR DESCRIPTION
Ported from 18F/pages#48.

cc: @adelevie @arowla 
