### PR TITLE
Fix `git stash && git pull` heisenbug

### DIFF
--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -124,7 +124,7 @@ SiteBuilder.prototype.syncRepo = function() {
   this.logger.log('syncing repo:', this.opts.repoName);
   var that = this;
   return this.spawn(config.git, ['stash'])
-    .then(function() { that.spawn(config.git, ['pull']); });
+    .then(function() { return that.spawn(config.git, ['pull']); });
 };
 
 SiteBuilder.prototype.cloneRepo = function() {

--- a/test/build-logger-test.js
+++ b/test/build-logger-test.js
@@ -70,7 +70,6 @@ describe('BuildLogger', function() {
 
   it ('should fail if the file cannot be written to', function(done) {
     logger = makeLogger(checkN(2, done, function() {
-      var expectedError = 'Error: EACCES, open \'' + logFilePath + '\'';
       // I expected the following to succeed, since the failing call happens
       // after the successful call:
       //
@@ -87,9 +86,8 @@ describe('BuildLogger', function() {
       expect(console.log.args[1].join(' '))
         .to.equal('This should not be logged to the file');
       expect(console.error.called).to.be.true;
-      expect(console.error.args[0].join(' '))
-        .to.equal('Error: failed to append to log file ' + logFilePath +
-          ': ' + expectedError);
+      expect(console.error.args[0].join(' ')).to.match(
+        /^Error: failed to append to log file .*: Error: EACCES/);
     }));
 
     captureLogs();


### PR DESCRIPTION
Discovered after the update from 18F/pages#26 successfully rebuilt, but the changes didn't appear, as reported by @emileighoutlaw. After poring over the logs and looking over the code, I realized I fell into the old trap of not returning the Promise generated by a callback, causing that Promise to execute free from the rest of the Promise chain.

Also noticed a platform-dependent test breakage after upgrading to Node v4.1.2 on my machine, and took care of that, too.

cc: @arowla @afeld @jeremiak 
