### PR TITLE
Bump github-webhook-validator to v0.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+- "5.0"
 - "4.2"
 - "4.1"
 - "4.0"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/18f/pages-server#readme",
   "dependencies": {
     "file-locked-operation": "0.0.1",
-    "github-webhook-validator": "0.1.0",
+    "github-webhook-validator": "0.1.1",
     "hookshot": "18f/hookshot#0.1.0-with-json-options"
   },
   "devDependencies": {

--- a/test/request-helper.js
+++ b/test/request-helper.js
@@ -23,8 +23,6 @@ RequestHelper.prototype.httpOptions = function(port, payload, secret) {
     path: '/',
     method: 'POST',
     headers: {
-      'Request URL': 'https://pages.18f.gov/deploy',
-      'Request method': 'POST',
       'content-type': 'application/json',
       'Expect': '',
       'User-Agent': 'GitHub-Hookshot/9db916b',

--- a/test/request-helper.js
+++ b/test/request-helper.js
@@ -13,7 +13,7 @@ function RequestHelper() {
 
 RequestHelper.prototype.makeSignature = function(payload, secret) {
   return 'sha1=' +
-    crypto.createHmac('sha1', secret).update(payload).digest('hex');
+    crypto.createHmac('sha1', secret).update(payload, 'utf8').digest('hex');
 };
 
 RequestHelper.prototype.httpOptions = function(port, payload, secret) {
@@ -30,7 +30,10 @@ RequestHelper.prototype.httpOptions = function(port, payload, secret) {
       'X-GitHub-Event': 'push',
       'X-Hub-Signature': this.makeSignature(payload, secret),
       'Content-Type': 'application/json',
-      'Content-Length': payload.length
+      // See the following for why payload.length doesn't cut it for
+      // Content-Length (note GitHub doesn't send Content-Length):
+      // https://stackoverflow.com/questions/17922748/
+      'Content-Length': Buffer.byteLength(payload, 'utf8')
     }
   };
 };
@@ -43,7 +46,9 @@ RequestHelper.prototype.makePayload = function(branch) {
       'full_name': '18F/foo',
       // Alter the name of the organization so the request is silently ignored
       // to avoid tons of server logging in the background.
-      'organization': '19G'
+      'organization': '19G',
+      // Include a UTF-8 character to ensure it’s handled correctly.
+      'description': 'The apostrophe in "it’s" is a UTF-8 character.'
     },
     'head_commit': {
       'id': 'deadbeef',
@@ -66,12 +71,12 @@ RequestHelper.prototype.sendRequest = function(options, payload) {
         if (res.statusCode >= 200 && res.statusCode <= 300) {
           resolve(data);
         } else {
-          reject(data);
+          reject(new Error(data));
         }
       });
     });
 
-    req.on('error', function(e) { reject(e.message); });
+    req.on('error', function(err) { reject(err); });
     req.write(payload);
     req.end();
   });


### PR DESCRIPTION
See 18F/github-webhook-validator#2 for the motivation. Even though just upgrading to github-webhook-validator v0.1.1 resolves the issue, I still wanted to make sure that the tests in this package were UTF-8-clean. Learned a surprising detail about UTF-8 Content-Length calculation in the process, explained with a comment in the test data.

Confirmed that reverting github-webhook-validator to v0.1.0 causes tests to fail, and that removing the `'utf8'` encoding specifier in `RequestHelper.makeSignature()` also causes the tests to fail with github-webhook-validator v0.1.1.

Also contains small updates for Node 5.0 compatibility and testing on Travis.

Once this is merged, I'll bump the 18f-pages-server version and deploy to fix the problem for good.

cc: @arowla @jeremiak @afeld @wslack 
