### PR TITLE
Add a `git submodule update --init` step

### DIFF
--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -106,7 +106,10 @@ SiteBuilder.prototype.syncRepo = function() {
   this.logger.log('syncing repo:', this.opts.repoName);
   var that = this;
   return this.spawn(config.git, ['stash'])
-    .then(function() { return that.spawn(config.git, ['pull']); });
+    .then(function() { return that.spawn(config.git, ['pull']); })
+    .then(function() {
+      return that.spawn(config.git, ['submodule', 'update', '--init']);
+    });
 };
 
 SiteBuilder.prototype.cloneRepo = function() {

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -241,6 +241,7 @@ describe('SiteBuilder', function() {
         expect(spawnCalls()).to.eql([
           'git stash',
           'git pull',
+          'git submodule update --init',
           'jekyll build --trace --destination dest_dir/repo_name ' +
             '--config _config.yml,_config_18f_pages.yml',
         ]);
@@ -263,6 +264,7 @@ describe('SiteBuilder', function() {
         expect(spawnCalls()).to.eql([
           'git stash',
           'git pull',
+          'git submodule update --init',
           'bundle install',
           'bundle exec jekyll build --trace --destination dest_dir/repo_name ' +
             '--config _config.yml,_config_18f_pages.yml',
@@ -275,6 +277,7 @@ describe('SiteBuilder', function() {
   it ('should fail if bundle install fails', function(done) {
     mySpawn.sequence.add(mySpawn.simple(0));
     mySpawn.sequence.add(mySpawn.simple(0));
+    mySpawn.sequence.add(mySpawn.simple(0));
     mySpawn.sequence.add(mySpawn.simple(1));
     logMock.expects('log').withExactArgs('syncing repo:', 'repo_name');
     filenameToContents[filesHelper.gemfile] = '';
@@ -284,13 +287,17 @@ describe('SiteBuilder', function() {
         expect(err).to.equal('Error: rebuild failed for repo_name with ' +
           'exit code 1 from command: ' + bundleInstallCommand);
         expect(spawnCalls()).to.eql([
-          'git stash', 'git pull', bundleInstallCommand]);
+          'git stash',
+          'git pull',
+          'git submodule update --init',
+          bundleInstallCommand]);
         logMock.verify();
       }));
     });
   });
 
   it ('should fail if jekyll build fails', function(done) {
+    mySpawn.sequence.add(mySpawn.simple(0));
     mySpawn.sequence.add(mySpawn.simple(0));
     mySpawn.sequence.add(mySpawn.simple(0));
     mySpawn.sequence.add(mySpawn.simple(0));
@@ -309,7 +316,11 @@ describe('SiteBuilder', function() {
         expect(err).to.equal('Error: rebuild failed for repo_name with ' +
           'exit code 1 from command: ' + jekyllBuildCommand);
         expect(spawnCalls()).to.eql([
-          'git stash', 'git pull', 'bundle install', jekyllBuildCommand]);
+          'git stash',
+          'git pull',
+          'git submodule update --init',
+          'bundle install',
+          jekyllBuildCommand]);
         logMock.verify();
       }));
     });
@@ -327,6 +338,7 @@ describe('SiteBuilder', function() {
         expect(spawnCalls()).to.eql([
           'git stash',
           'git pull',
+          'git submodule update --init',
           'jekyll build --trace --destination dest_dir/repo_name ' +
             '--config _config.yml,_config_18f_pages.yml',
         ]);
@@ -348,6 +360,7 @@ describe('SiteBuilder', function() {
         expect(spawnCalls()).to.eql([
           'git stash',
           'git pull',
+          'git submodule update --init',
           'jekyll build --trace --destination dest_dir/new-destination ' +
             '--config _config.yml,_config_18f_pages.yml',
         ]);
@@ -368,6 +381,7 @@ describe('SiteBuilder', function() {
             expect(spawnCalls()).to.eql([
               'git stash',
               'git pull',
+              'git submodule update --init',
               'rsync -vaxp --delete --ignore-errors --exclude=.[A-Za-z0-9]* ' +
                 './ dest_dir/repo_name',
             ]);
@@ -388,7 +402,9 @@ describe('SiteBuilder', function() {
           expect(err).to.equal('Error: failed to build a site with a ' +
             '_config_internal.yml file without an internalSiteDir defined ' +
             'in the builder configuration');
-          expect(spawnCalls()).to.eql(['git stash', 'git pull']);
+          expect(spawnCalls()).to.eql([
+            'git stash', 'git pull', 'git submodule update --init'
+          ]);
           logMock.verify();
         }));
       });
@@ -404,7 +420,9 @@ describe('SiteBuilder', function() {
           expect(err).to.equal('Error: failed to build a site with a ' +
             '_config_external.yml file without a corresponding ' +
             '_config_internal.yml file');
-          expect(spawnCalls()).to.eql(['git stash', 'git pull']);
+          expect(spawnCalls()).to.eql([
+            'git stash', 'git pull', 'git submodule update --init'
+          ]);
           logMock.verify();
         }));
       });
@@ -428,6 +446,7 @@ describe('SiteBuilder', function() {
           expect(spawnCalls()).to.eql([
             'git stash',
             'git pull',
+            'git submodule update --init',
             'jekyll build --trace --destination internal_dest_dir/repo_name ' +
               '--config _config.yml,_config_internal.yml,_config_18f_pages.yml',
             'jekyll build --trace --destination dest_dir/repo_name ' +
@@ -457,6 +476,7 @@ describe('SiteBuilder', function() {
           expect(spawnCalls()).to.eql([
             'git stash',
             'git pull',
+            'git submodule update --init',
             'jekyll build --trace --destination internal_dest_dir/repo_name ' +
               '--config _config.yml,_config_internal.yml,_config_18f_pages.yml',
             'jekyll build --trace --destination dest_dir/repo_name ' +


### PR DESCRIPTION
Turns out 18F/brand#18f-pages-staging is mounting 18F/web-design-standards as a submodule. Confirmed locally that `git submodule update --init` checks out that branch correctly, and successfully does nothing when no submodules are present or no updates are warranted.

Once this goes in, I'll publish a new version and launch it on https://pages.18f.gov/.

cc: @ccostino @arowla @afeld @maya
