### PR TITLE
Post to a URL including the branch name

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -39,4 +39,8 @@ function Options(info, config, builderConfig) {
   this.githubOrg = builderConfig.githubOrg || config.githubOrg;
   this.pagesConfig = builderConfig.pagesConfig || config.pagesConfig;
   this.assetRoot = builderConfig.assetRoot || config.assetRoot;
+
+  if (builderConfig.branchInUrlPattern) {
+    this.branchInUrlPattern = new RegExp(builderConfig.branchInUrlPattern, 'i');
+  }
 }

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -290,13 +290,15 @@ exports.launchBuilder = function(info, builderConfig, done) {
 };
 
 exports.makeBuilderListener = function(webhook, builderConfig, done) {
-  var org = builderConfig.githubOrg || config.githubOrg;
-
-  webhook.on('refs/heads/' + builderConfig.branch, function(info) {
-    if (info.repository.organization === org) {
-      exports.launchBuilder(info, builderConfig, done);
-    }
-  });
+  var org = builderConfig.githubOrg || config.githubOrg,
+      handler = function(info) {
+        if (info.ref === ('refs/heads/' + builderConfig.branch) &&
+          info.repository.organization === org) {
+          exports.launchBuilder(info, builderConfig, done);
+        }
+      };
+  webhook.on('create', handler);
+  webhook.on('push', handler);
 };
 
 exports.SiteBuilder = SiteBuilder;

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -304,15 +304,19 @@ exports.launchBuilder = function(info, branch, builderConfig, done) {
 
 exports.makeBuilderListener = function(webhook, builderConfig, done) {
   var org = builderConfig.githubOrg || config.githubOrg,
-      branchRegexp = new RegExp('refs/heads/(' +
-        (builderConfig.branchInUrlPattern || builderConfig.branch) + ')'),
-      handler = function(info) {
-        var branch = branchRegexp.exec(info.ref);
+      branchPattern = builderConfig.branchInUrlPattern || builderConfig.branch,
+      branchRegexp,
+      handler;
 
-        if (branch && (info.repository.organization === org)) {
-          exports.launchBuilder(info, branch[1], builderConfig, done);
-        }
-      };
+  branchRegexp = new RegExp('refs/heads/(' + branchPattern + ')');
+
+  handler = function(info) {
+    var branch = branchRegexp.exec(info.ref);
+
+    if (branch && (info.repository.organization === org)) {
+      exports.launchBuilder(info, branch[1], builderConfig, done);
+    }
+  };
   webhook.on('create', handler);
   webhook.on('push', handler);
 };

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -203,10 +203,17 @@ SiteBuilder.prototype.readOrWriteConfig = function(configExists) {
 
   this.logger.log('generating', this.opts.pagesConfig);
   return new Promise(function(resolve, reject) {
+    var content,
+        baseurl = '/' + that.opts.repoName;
+
+    if (that.opts.branchInUrlPattern) {
+      baseurl = baseurl + '/' + that.branch;
+    }
+
     // asset_root: is used by the guides_style_18f gem to ensure that updates
     // to common CSS and JavaScript files can be applied to Pages without
     // having to update the gem.
-    var content = 'baseurl: /' + that.opts.repoName + '\n' +
+    content = 'baseurl: ' + baseurl + '\n' +
       'asset_root: ' + that.opts.assetRoot + '\n';
     fs.writeFile(configPath, content, function(err) {
       if (err) { return reject(err); }
@@ -234,6 +241,10 @@ JekyllCommandHelper.prototype.spawn = function(destination, extraConfig) {
   }
   configs.push(this.builder.opts.pagesConfig);
   configs = configs.join(',');
+
+  if (this.builder.opts.branchInUrlPattern) {
+    destination = destination + '/' + this.builder.branch;
+  }
 
   var args = this.args.concat(destination).concat('--config').concat(configs);
   return this.builder.spawn(this.jekyll, args);

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -24,10 +24,12 @@ exports.setConfiguration = function(configuration) {
 // machine that are executed asynchronously via callbacks.
 //
 // opts: Options object
+// branch: Branch to build
 // buildLogger: BuildLogger instance
 // updateLock: FileLockedOperation instance
-function SiteBuilder(opts, buildLogger, updateLock) {
+function SiteBuilder(opts, branch, buildLogger, updateLock) {
   this.opts = opts;
+  this.branch = branch;
   this.logger = buildLogger;
   this.updateLock = updateLock;
   this.buildDestination = path.join(opts.destDir, opts.repoName);
@@ -249,7 +251,7 @@ SiteBuilder.prototype.jekyllBuild = function() {
     .then(function() { return helper.spawn(that.buildDestination, extConf); });
 };
 
-exports.launchBuilder = function(info, builderConfig, done) {
+exports.launchBuilder = function(info, branch, builderConfig, done) {
   var builderOpts = new Options(info, config, builderConfig);
   var commit = info.head_commit;  // jshint ignore:line
   var buildLog = builderOpts.sitePath + '.log';
@@ -266,7 +268,7 @@ exports.launchBuilder = function(info, builderConfig, done) {
     '.update-lock-' + builderOpts.repoName);
   var updateLock = new fileLockedOperation.FileLockedOperation(lockfilePath,
     { wait: config.fileLockWaitTime, poll: config.fileLockPollTime });
-  var builder = new SiteBuilder(builderOpts, logger, updateLock);
+  var builder = new SiteBuilder(builderOpts, branch, logger, updateLock);
 
   builder.build(function(err) {
     if (err !== undefined) {
@@ -297,7 +299,7 @@ exports.makeBuilderListener = function(webhook, builderConfig, done) {
         var branch = branchRegexp.exec(info.ref);
 
         if (branch && (info.repository.organization === org)) {
-          exports.launchBuilder(info, builderConfig, done);
+          exports.launchBuilder(info, branch, builderConfig, done);
         }
       };
   webhook.on('create', handler);

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -119,7 +119,7 @@ SiteBuilder.prototype.cloneRepo = function() {
 
   var cloneAddr = 'git@github.com:' + this.opts.githubOrg + '/' +
     this.opts.repoName + '.git';
-  var cloneArgs = ['clone', cloneAddr, '--branch', this.opts.branch];
+  var cloneArgs = ['clone', cloneAddr, '--branch', this.branch];
   var cloneOpts = {cwd: this.opts.repoDir, stdio: 'inherit'};
   var that = this;
 
@@ -299,7 +299,7 @@ exports.makeBuilderListener = function(webhook, builderConfig, done) {
         var branch = branchRegexp.exec(info.ref);
 
         if (branch && (info.repository.organization === org)) {
-          exports.launchBuilder(info, branch, builderConfig, done);
+          exports.launchBuilder(info, branch[1], builderConfig, done);
         }
       };
   webhook.on('create', handler);

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -291,9 +291,12 @@ exports.launchBuilder = function(info, builderConfig, done) {
 
 exports.makeBuilderListener = function(webhook, builderConfig, done) {
   var org = builderConfig.githubOrg || config.githubOrg,
+      branchRegexp = new RegExp('refs/heads/(' +
+        (builderConfig.branchInUrlPattern || builderConfig.branch) + ')'),
       handler = function(info) {
-        if (info.ref === ('refs/heads/' + builderConfig.branch) &&
-          info.repository.organization === org) {
+        var branch = branchRegexp.exec(info.ref);
+
+        if (branch && (info.repository.organization === org)) {
           exports.launchBuilder(info, builderConfig, done);
         }
       };

--- a/pages-config.json
+++ b/pages-config.json
@@ -19,12 +19,24 @@
     {
       "branch":           "18f-pages",
       "repositoryDir":    "pages-repos",
-      "generatedSiteDir": "pages-generated"
+      "generatedSiteDir": "pages-generated",
+      "internalSiteDir":  "pages-internal"
     },
     {
       "branch":           "18f-pages-staging",
       "repositoryDir":    "pages-repos-staging",
-      "generatedSiteDir": "pages-staging"
+      "generatedSiteDir": "pages-staging",
+      "internalSiteDir":  "pages-internal"
+    },
+    {
+      "branch":           "18f-pages-internal",
+      "repositoryDir":    "pages-repos-internal",
+      "generatedSiteDir": "pages-internal"
+    },
+    {
+      "branchInUrlPattern": "v[0-9]+.[0-9]+.[0-9]*[a-z]+",
+      "repositoryDir":      "pages-repos-releases",
+      "generatedSiteDir":   "pages-releases"
     }
   ]
 }

--- a/test/options-test.js
+++ b/test/options-test.js
@@ -58,7 +58,8 @@ describe('Options', function() {
       'branch': 'foobar-pages',
       'repositoryDir': 'repo_dir',
       'generatedSiteDir': 'dest_dir',
-      'assetRoot': '/foobar-template'
+      'assetRoot': '/foobar-template',
+      'branchInUrlPattern': 'v[0-9\]+.[0-9]+.[0-9]*[a-z]+',
     };
 
     var opts = new Options(info, config, builderConfig);
@@ -71,6 +72,8 @@ describe('Options', function() {
     expect(opts.githubOrg).to.equal('foobar');
     expect(opts.pagesConfig).to.equal('_config_foobar_pages.yml');
     expect(opts.assetRoot).to.equal('/foobar-template');
+    expect(opts.branchInUrlPattern.toString()).to.equal(
+      '/' + builderConfig.branchInUrlPattern + '/i');
   });
 
   it('should set internalDestDir when internalSiteDir defined', function() {

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -117,11 +117,11 @@ describe('SiteBuilder', function() {
     };
 
     checkResults = function(content) {
-      expect(content).to.equal('baseurl: /repo_name\n' +
-        'asset_root: ' + config.assetRoot + '\n');
       return new Promise(function(resolve, reject) {
         // Note the done callback wrapper will remove the generated config.
         var buildDone = builder.generateBuildDone(function(err) {
+          expect(content).to.equal('baseurl: /repo_name\n' +
+            'asset_root: ' + config.assetRoot + '\n');
           if (err) { reject(err); } else { resolve(); }
         });
         buildDone();

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -88,7 +88,7 @@ describe('SiteBuilder', function() {
   var makeBuilder = function(opts) {
     if (!opts) { opts = makeOpts(); }
     opts.sitePath = filesHelper.testRepoDir;
-    return new siteBuilder.SiteBuilder(opts, logger, updateLock);
+    return new siteBuilder.SiteBuilder(opts, '18f-pages', logger, updateLock);
   };
 
   it('should write the expected configuration', function(done) {

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -219,7 +219,7 @@ describe('SiteBuilder', function() {
     logMock.expects('log').withExactArgs(
       'cloning', 'repo_name', 'into', filesHelper.testRepoDir);
     makeBuilder().build(check(done, function(err) {
-      var cloneCommand = 
+      var cloneCommand =
         'git clone git@github.com:18F/repo_name.git --branch 18f-pages';
       expect(err).to.equal('Error: failed to clone repo_name with ' +
         'exit code 1 from command: ' + cloneCommand);

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -559,12 +559,14 @@ describe('SiteBuilder', function() {
 
     it('should create a function to launch a builder', function() {
       siteBuilder.makeBuilderListener(webhook, builderConfig);
-      expect(webhook.on.calledOnce).to.be.true;
-      var args = webhook.on.args[0];
-      expect(args.length).to.equal(2);
-      expect(args[0]).to.equal('refs/heads/18f-pages');
-      var launcher = args[1];
-      expect(launcher).to.be.a.Function;
+      expect(webhook.on.calledTwice).to.be.true;
+      expect(webhook.on.args[0].length).to.equal(2);
+      expect(webhook.on.args[0][0]).to.equal('create');
+      expect(webhook.on.args[1][0]).to.equal('push');
+      expect(webhook.on.args[1].length).to.equal(2);
+      expect(webhook.on.args[0][1]).to.be.a.Function;
+      expect(webhook.on.args[1][1]).to.be.a.Function;
+      expect(webhook.on.args[0][1]).to.equal(webhook.on.args[1][1]);
     });
 
     it('should create a builder that builds the site', function(done) {

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -91,25 +91,23 @@ describe('SiteBuilder', function() {
     return new siteBuilder.SiteBuilder(opts, '18f-pages', logger, updateLock);
   };
 
-  it('should write the expected configuration', function(done) {
-    builder = makeBuilder();
-    logMock.expects('log').withExactArgs(
-      'generating', config.pagesConfig);
-    logMock.expects('log').withExactArgs(
-      'removing generated', config.pagesConfig);
+  describe('generated configuration', function() {
+    var inRepoDir, writeConfig, readConfig, checkResults;
 
-    var inRepoDir = new Promise(function(resolve, reject) {
-      filesHelper.createRepoDir(function(err) {
-        if (err) { reject(err); } else { resolve(); }
+    inRepoDir = function() {
+      return new Promise(function(resolve, reject) {
+        filesHelper.createRepoDir(function(err) {
+          if (err) { reject(err); } else { resolve(); }
+        });
       });
-    });
+    };
 
-    var writeConfig = function() {
+    writeConfig = function() {
       var configExists;
       return builder.readOrWriteConfig(configExists = false);
     };
 
-    var readConfig = function() {
+    readConfig = function() {
       expect(builder.generatedConfig).to.be.true;
       return new Promise(function(resolve, reject) {
         fs.readFile(filesHelper.pagesConfig, function(err, data) {
@@ -118,7 +116,7 @@ describe('SiteBuilder', function() {
       });
     };
 
-    var checkResults = function(content) {
+    checkResults = function(content) {
       expect(content).to.equal('baseurl: /repo_name\n' +
         'asset_root: ' + config.assetRoot + '\n');
       return new Promise(function(resolve, reject) {
@@ -130,8 +128,16 @@ describe('SiteBuilder', function() {
       });
     };
 
-    inRepoDir.then(writeConfig).then(readConfig).then(checkResults)
-        .then(function() { logMock.verify(); }).should.notify(done);
+    it('should write the expected configuration', function(done) {
+      builder = makeBuilder();
+      logMock.expects('log').withExactArgs(
+        'generating', config.pagesConfig);
+      logMock.expects('log').withExactArgs(
+        'removing generated', config.pagesConfig);
+
+      inRepoDir().then(writeConfig).then(readConfig).then(checkResults)
+          .then(function() { logMock.verify(); }).should.notify(done);
+    });
   });
 
   // Note that this internal function will only get called when a


### PR DESCRIPTION
I still need to update the README, and the code is ripe for some refactoring probably, but this scheme does allow for a `branchInUrlPattern` configuration that will allow URLs such as `/foobar/v0.9.x`.

@msecret If you want to start the review, I'll get the README updated later. Also feel free to press me on some refactoring.

When this is done, I'll post this configuration and get pages-releases.18f.gov running.

cc: @maya @arowla @ccostino @ertzeid 
