### PR TITLE
Convert build-logger to custom type constructor

### DIFF
--- a/lib/build-logger.js
+++ b/lib/build-logger.js
@@ -3,7 +3,8 @@
 'use strict';
 
 var fs = require('fs');
-var exports = module.exports = {};
+
+module.exports = BuildLogger;
 
 // Message logger that logs both to the console and a repo-specific build.log.
 function BuildLogger(logFilePath, writeCb) {
@@ -31,5 +32,3 @@ BuildLogger.prototype.error = function() {
   console.error(message);
   this.logWrite(message);
 };
-
-exports.BuildLogger = BuildLogger;

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -4,7 +4,7 @@
 
 var fs = require('fs');
 var path = require('path');
-var buildLogger = require('./build-logger');
+var BuildLogger = require('./build-logger');
 var Options = require('./options');
 var fileLockedOperation = require('file-locked-operation');
 var childProcess = require('child_process');
@@ -266,7 +266,7 @@ exports.launchBuilder = function(info, branch, builderConfig, done) {
   var builderOpts = new Options(info, config, builderConfig);
   var commit = info.head_commit;  // jshint ignore:line
   var buildLog = builderOpts.sitePath + '.log';
-  var logger = new buildLogger.BuildLogger(buildLog);
+  var logger = new BuildLogger(buildLog);
   logger.log(info.repository.full_name + ':',   // jshint ignore:line
     'starting build at commit', commit.id);
   logger.log('description:', commit.message);

--- a/test/build-logger-test.js
+++ b/test/build-logger-test.js
@@ -7,8 +7,7 @@ var path = require('path');
 var fs = require('fs');
 var chai = require('chai');
 var sinon = require('sinon');
-var buildLogger = require(
-  path.resolve(path.dirname(__dirname), 'lib', 'build-logger.js'));
+var BuildLogger = require('../lib/build-logger.js');
 
 var expect = chai.expect;
 chai.should();
@@ -40,7 +39,7 @@ describe('BuildLogger', function() {
   });
 
   var makeLogger = function(done) {
-    return new buildLogger.BuildLogger(logFilePath, done);
+    return new BuildLogger(logFilePath, done);
   };
 
   var captureLogs = function() {

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -12,7 +12,7 @@ var childProcess = require('child_process');
 var mockSpawn = require('mock-spawn');
 var Options = require('../lib/options');
 var siteBuilder = require('../lib/site-builder');
-var buildLogger = require('../lib/build-logger');
+var BuildLogger = require('../lib/build-logger');
 var fileLockedOperation = require('file-locked-operation');
 
 var FilesHelper = require('./files-helper');
@@ -47,7 +47,7 @@ describe('SiteBuilder', function() {
     origSpawn = childProcess.spawn;
     mySpawn = mockSpawn();
     childProcess.spawn = mySpawn;
-    logger = new buildLogger.BuildLogger('/dev/null');
+    logger = new BuildLogger('/dev/null');
     logMock = sinon.mock(logger);
     updateLock = new fileLockedOperation.FileLockedOperation(
       filesHelper.lockfilePath);


### PR DESCRIPTION
Per http://thenodeway.io/posts/designing-custom-types/.

I've another `BuildLogger` refactor commit, but #23 needs to go in first.

cc: @msecret @rogeruiz 
