### PR TITLE
Handle empty baseurl from .18f-pages.yml

### DIFF
--- a/lib/config-handler.js
+++ b/lib/config-handler.js
@@ -62,7 +62,12 @@ function assignPagesYamlAttributes(handler, attributes) {
   Object.keys(attributes).forEach(function(key) {
     handler[key] = attributes[key];
   });
-  if (handler.baseurl) {
+
+  if (handler.baseurl === null) {
+    handler.baseurl = '';
+  }
+
+  if (handler.baseurl !== undefined) {
     setBuildDestinationFromBaseurl(handler, handler.baseurl);
   }
 }

--- a/test/config-handler-test.js
+++ b/test/config-handler-test.js
@@ -210,6 +210,27 @@ describe('ConfigHandler', function() {
         });
     });
 
+    it('should set an empty baseurl from .18f-pages.yml', function() {
+      fileHandler.exists.withArgs(pagesConfig.pagesYaml)
+        .returns(Promise.resolve(true));
+      fileHandler.readFile.withArgs(pagesConfig.pagesYaml)
+        .returns(Promise.resolve('baseurl:\n'));
+
+      return handler.init().should.be.fulfilled
+        .then(function() {
+          handler.hasPagesYaml.should.be.true;
+          handler.baseurl.should.eql('');
+          handler.buildDestination.should.eql(path.join(handler.destDir));
+          handler.internalBuildDestination.should.eql(
+            path.join(handler.internalDestDir));
+          handler.buildConfigurations().should.eql([
+            { destination: path.join('dest_dir'),
+              configurations: '_config.yml,' + config.pagesConfig
+            }
+          ]);
+        });
+    });
+
     it('should pass through any YAML errors', function() {
       fileHandler.exists.withArgs(pagesConfig.pagesYaml)
         .returns(Promise.resolve(true));


### PR DESCRIPTION
Before this change, the code interpreted an empty `baseurl:` in .18f-pages.yml as not having set a `baseurl:` at all, so the server would still generate a `baseurl:` out of the repository name.

In the interest of expedience, I'm going to merge this and push v0.2.1.

cc: @catherinedevlin @msecret @andrewmaier @mtorres253 @nicoleslaw @jeremiak 
