### PR TITLE
Add repo name to dest dir for empty baseurl

### DIFF
--- a/lib/config-handler.js
+++ b/lib/config-handler.js
@@ -67,7 +67,7 @@ function assignPagesYamlAttributes(handler, attributes) {
     handler.baseurl = '';
   }
 
-  if (handler.baseurl !== undefined) {
+  if (handler.baseurl) {
     setBuildDestinationFromBaseurl(handler, handler.baseurl);
   }
 }
@@ -130,7 +130,10 @@ function writeConfig(handler) {
 
   handler.logger.log('generating', handler.pagesConfig);
 
-  baseurl = handler.baseurl || ('/' + handler.repoName);
+  baseurl = handler.baseurl;
+  if (baseurl === undefined) {
+    baseurl = '/' + handler.repoName;
+  }
   assetRoot = handler.assetRoot;
 
   if (handler.branchInUrlPattern) {


### PR DESCRIPTION
The solution from #39 was incorrect. If there is a .18f-pages.yml file with an empty `baseurl:` property, we should still generate it into a directory with the same name as the repository. The web server configuration will need to contain this directory as the document root for the target site.

For example, for 18F/handbook, the baseurl will be empty, the output directory will be GENERATED_SITE_DIR/handbook, and the web server config will set GENERATED_SITE_DIR/handbook as the root for handbook.18f.gov.

cc: @msecret @catherinedevlin 
