### PR TITLE
Set the bundle install path

### DIFF
--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -43,7 +43,9 @@ SiteBuilder.prototype.build = function() {
       })
       .then(function() {
         if (builder.configHandler.usesBundler) {
-          return builder.commandRunner.run(config.bundler, ['install']);
+          return builder.commandRunner.run(
+            config.bundler, ['install',
+              '--path=' + path.join(config.home, config.bundlerCacheDir)]);
         }
       })
       .then(function() {

--- a/pages-config.json
+++ b/pages-config.json
@@ -1,12 +1,15 @@
 {
   "port":             5000,
-  "home":             "/home/ubuntu",
+  "home":             "/usr/local/18f/pages",
   "git":              "/usr/bin/git",
-  "bundler":          "/usr/local/rbenv/shims/bundle",
-  "jekyll":           "/usr/local/rbenv/shims/jekyll",
+  "bundler":          "/usr/local/18f/rbenv/shims/bundle",
+  "jekyll":           "/usr/local/18f/rbenv/shims/jekyll",
   "rsync":            "/usr/bin/rsync",
   "rsyncOpts":        [
-    "-vaxp", "--delete", "--ignore-errors", "--exclude=.[A-Za-z0-9]*"
+    "-vaxp",
+    "--delete",
+    "--ignore-errors",
+    "--exclude=.[A-Za-z0-9]*"
   ],
   "payloadLimit":     1048576,
   "githubOrg":        "18F",
@@ -15,29 +18,29 @@
   "assetRoot":        "/guides-template",
   "fileLockWaitTime": 30000,
   "fileLockPollTime": 1000,
-  "secretKeyFile":    "/home/ubuntu/.18f-pages.secret",
+  "secretKeyFile":    "/usr/local/18f/pages/config/pages.secret",
   "builders": [
     {
       "branch":           "18f-pages",
-      "repositoryDir":    "pages-repos",
-      "generatedSiteDir": "pages-generated",
-      "internalSiteDir":  "pages-internal"
+      "repositoryDir":    "repos/pages.18f.gov",
+      "generatedSiteDir": "sites/pages.18f.gov",
+      "internalSiteDir":  "sites/pages-internal.18f.gov"
     },
     {
       "branch":           "18f-pages-staging",
-      "repositoryDir":    "pages-repos-staging",
-      "generatedSiteDir": "pages-staging",
-      "internalSiteDir":  "pages-internal"
+      "repositoryDir":    "repos/pages-staging.18f.gov",
+      "generatedSiteDir": "sites/pages-staging.18f.gov",
+      "internalSiteDir":  "sites/pages-internal.18f.gov"
     },
     {
       "branch":           "18f-pages-internal",
-      "repositoryDir":    "pages-repos-internal",
-      "generatedSiteDir": "pages-internal"
+      "repositoryDir":    "repos/pages-internal.18f.gov",
+      "generatedSiteDir": "sites/pages-internal.18f.gov"
     },
     {
-      "branchInUrlPattern": "v[0-9]+.[0-9]+.[0-9]*[a-z]+",
-      "repositoryDir":      "pages-repos-releases",
-      "generatedSiteDir":   "pages-releases"
+      "branchInUrlPattern": "v[0-9]+.[0-9]+.[0-9]*[a-z]*",
+      "repositoryDir":      "repos/pages-releases.18f.gov",
+      "generatedSiteDir":   "sites/pages-releases.18f.gov"
     }
   ]
 }

--- a/pages-config.json
+++ b/pages-config.json
@@ -3,6 +3,7 @@
   "home":             "/usr/local/18f/pages",
   "git":              "/usr/bin/git",
   "bundler":          "/usr/local/18f/rbenv/shims/bundle",
+  "bundlerCacheDir":  "bundler-cache",
   "jekyll":           "/usr/local/18f/rbenv/shims/jekyll",
   "rsync":            "/usr/bin/rsync",
   "rsyncOpts":        [

--- a/test/options-test.js
+++ b/test/options-test.js
@@ -31,12 +31,12 @@ describe('Options', function() {
     };
 
     var opts = new Options(info, config, builderConfig);
-    expect(opts.repoDir).to.equal(path.join('/home/ubuntu/repo_dir'));
+    expect(opts.repoDir).to.equal(path.join(config.home, 'repo_dir'));
     expect(opts.repoName).to.equal('repo_name');
     expect(opts.sitePath).to.equal(
-      path.join('/home/ubuntu/repo_dir/repo_name'));
+      path.join(config.home, 'repo_dir/repo_name'));
     expect(opts.branch).to.equal('18f-pages');
-    expect(opts.destDir).to.equal(path.join('/home/ubuntu/dest_dir'));
+    expect(opts.destDir).to.equal(path.join(config.home, 'dest_dir'));
     expect(opts.internalDestDir).to.be.undefined;
     expect(opts.githubOrg).to.equal('18F');
     expect(opts.pagesConfig).to.equal('_config_18f_pages.yml');
@@ -63,12 +63,12 @@ describe('Options', function() {
     };
 
     var opts = new Options(info, config, builderConfig);
-    expect(opts.repoDir).to.equal(path.join('/home/ubuntu/repo_dir'));
+    expect(opts.repoDir).to.equal(path.join(config.home, 'repo_dir'));
     expect(opts.repoName).to.equal('repo_name');
     expect(opts.sitePath).to.equal(
-      path.join('/home/ubuntu/repo_dir/repo_name'));
+      path.join(config.home, 'repo_dir/repo_name'));
     expect(opts.branch).to.equal('foobar-pages');
-    expect(opts.destDir).to.equal(path.join('/home/ubuntu/dest_dir'));
+    expect(opts.destDir).to.equal(path.join(config.home, 'dest_dir'));
     expect(opts.internalDestDir).to.be.undefined;
     expect(opts.githubOrg).to.equal('foobar');
     expect(opts.pagesConfig).to.equal('_config_foobar_pages.yml');
@@ -94,8 +94,8 @@ describe('Options', function() {
     };
 
     var opts = new Options(info, config, builderConfig);
-    expect(opts.destDir).to.equal(path.join('/home/ubuntu/dest_dir'));
+    expect(opts.destDir).to.equal(path.join(config.home, 'dest_dir'));
     expect(opts.internalDestDir).to.equal(
-      path.join('/home/ubuntu/internal_dest_dir'));
+      path.join(config.home, 'internal_dest_dir'));
   });
 });

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -28,6 +28,7 @@ describe('SiteBuilder', function() {
     config.home = '';
     config.git = 'git';
     config.bundler = 'bundle';
+    config.bundlerCacheDir = 'bundler_cache_dir';
     config.jekyll = 'jekyll';
     config.rsync = 'rsync';
   }
@@ -155,7 +156,9 @@ describe('SiteBuilder', function() {
           builder.gitRunner.prepareRepo.args.should.eql([[builder.branch]]);
           builder.configHandler.init.called.should.be.true;
           builder.commandRunner.run.args.should.eql([
-            [config.bundler, ['install']]
+            [config.bundler,
+             ['install',
+              '--path=' + path.join(config.home, config.bundlerCacheDir)]]
           ]);
           builder.configHandler.readOrWriteConfig.called.should.be.true;
           builder.jekyllHelper.build.args.should.eql([


### PR DESCRIPTION
This is necessary since the containerized [18F/knowledge-sharing-toolkit](https://github.com/18F/knowledge-sharing-toolkit) version will not enable the pages-server user to install gems to the system location.

Also updates `pages-config.json` to match that of 18F/knowledge-sharing-toolkit. The tests now use path.join() to add config.home to the expected file paths.

cc: @msecret @DavidEBest @rogeruiz 
