### PR TITLE
Pipe command logs to logger

### DIFF
--- a/lib/command-runner.js
+++ b/lib/command-runner.js
@@ -4,9 +4,10 @@ var childProcess = require('child_process');
 
 module.exports = CommandRunner;
 
-function CommandRunner(sitePath, repoName) {
+function CommandRunner(sitePath, repoName, logger) {
   this.sitePath = sitePath;
   this.repoName = repoName;
+  this.logger = logger;
 }
 
 CommandRunner.prototype.run = function(path, args, opts, message) {
@@ -15,10 +16,23 @@ CommandRunner.prototype.run = function(path, args, opts, message) {
 
 function doRun(runner, path, args, opts, message) {
   return new Promise(function(resolve, reject) {
-    var options = opts || {cwd: runner.sitePath, stdio: 'inherit'},
+    var command,
+        options = opts || {cwd: runner.sitePath},
         msg = message || 'rebuild failed for';
 
-    childProcess.spawn(path, args, options).on('close', function(code) {
+    command = childProcess.spawn(path, args, options);
+
+    command.stdout.setEncoding('utf8');
+    command.stdout.on('data', function(data) {
+      runner.logger.log(data);
+    });
+
+    command.stderr.setEncoding('utf8');
+    command.stderr.on('data', function(data) {
+      runner.logger.error(data);
+    });
+
+    command.on('close', function(code) {
       if (code !== 0) {
         reject('Error: ' + msg + ' ' + runner.repoName + ' with exit code ' +
           code + ' from command: ' + path + ' ' + args.join(' '));

--- a/lib/component-factory.js
+++ b/lib/component-factory.js
@@ -12,7 +12,7 @@ module.exports = ComponentFactory;
 
 function ComponentFactory(config, builderOpts, branch, logger) {
   this.commandRunner = new CommandRunner(
-    builderOpts.sitePath, builderOpts.repoName);
+    builderOpts.sitePath, builderOpts.repoName, logger);
   this.configHandler = new ConfigHandler(
     builderOpts, branch,
     new RepositoryFileHandler(builderOpts.sitePath), logger);

--- a/test/build-logger-test.js
+++ b/test/build-logger-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var BuildLogger = require('../lib/build-logger.js');
+var BuildLogger = require('../lib/build-logger');
 var path = require('path');
 var fs = require('fs');
 var sinon = require('sinon');

--- a/test/command-runner-test.js
+++ b/test/command-runner-test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var CommandRunner = require('../lib/command-runner');
+var sinon = require('sinon');
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+
+var TEST_COMMAND = 'fake-command.js';
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('CommandRunner', function() {
+  var runner, fakeLogger;
+
+  beforeEach(function() {
+    fakeLogger = { log: sinon.spy(), error: sinon.spy() };
+    runner = new CommandRunner(__dirname, 'pages-server', fakeLogger);
+  });
+
+  it('should pass stdout to the logger and exit normally', function() {
+    return runner.run('node', [TEST_COMMAND, 'foo', 'bar', 'baz'])
+      .should.be.fulfilled.then(function() {
+        fakeLogger.log.args.should.eql([['foo bar baz\n']]);
+        sinon.assert.notCalled(fakeLogger.error);
+      });
+  });
+
+  it('should pass stderr to the logger, exit with error message', function() {
+    return runner.run('node', [TEST_COMMAND], null, 'test command failed for')
+      .should.be.rejectedWith('Error: test command failed for pages-server ' +
+        'with exit code 1 from command: node ' + TEST_COMMAND)
+      .then(function() {
+        sinon.assert.notCalled(fakeLogger.log);
+        fakeLogger.error.args.should.eql(
+          [['no arguments passed on the command line\n']]);
+      });
+  });
+});

--- a/test/fake-command.js
+++ b/test/fake-command.js
@@ -1,0 +1,15 @@
+#! /usr/bin/env node
+/*
+ * This is for command-runner-test.js. It will echo its command line args if
+ * there are any, and exit with zero status. If there are no command line
+ * args, it will write to stderr and exit with an error status.
+ */
+
+var message = process.argv.slice(2);
+
+if (message.length !== 0) {
+  process.stdout.write(message.join(' ') + '\n');
+} else {
+  process.stderr.write('no arguments passed on the command line\n');
+  process.exit(1);
+}


### PR DESCRIPTION
By doing this, command output will go to both the standard output and error of the pages-server (as it already did) and to the build-specific log file.

cc: @msecret @DavidEBest @rogeruiz 
