### PR TITLE
Sync to S3 upon a successful build

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ illustrates each of the following settings:
 * **rsync**: path to `rsync` on the host machine
 * **rsyncOpts**: options to pass to `rsync` that control Jekyll-less builds;
   OS X installations in particular may need to adjust these
+* **s3 (optional)**: if present, will back up each generated site to
+  [Amazon S3](https://aws.amazon.com/s3/); attributes are:
+  * **awscli**: path to the [`aws` command](https://aws.amazon.com/cli/) on
+    the host machine
+  * **bucket**: address of the S3 bucket to which to sync generated sites
 * **payloadLimit**: maximum allowable size (in bytes) for incoming webhooks
 * **githubOrg**: GitHub organization to which all published repositories
   belong

--- a/lib/component-factory.js
+++ b/lib/component-factory.js
@@ -5,6 +5,7 @@ var RepositoryFileHandler = require('./repository-file-handler');
 var ConfigHandler = require('./config-handler');
 var GitRunner = require('./git-runner');
 var JekyllCommandHelper = require('./jekyll-command-helper');
+var Sync = require('./sync');
 var FileLockedOperation = require('file-locked-operation');
 var path = require('path');
 
@@ -19,6 +20,7 @@ function ComponentFactory(config, builderOpts, branch, logger) {
   this.jekyllHelper = new JekyllCommandHelper(config, this.commandRunner);
   this.gitRunner = new GitRunner(
     config, builderOpts, this.commandRunner, logger);
+  this.sync = new Sync(config, this.commandRunner, logger);
   this.updateLock = new FileLockedOperation(
     path.join(builderOpts.destDir, '.update-lock-' + builderOpts.repoName),
     { wait: config.fileLockWaitTime, poll: config.fileLockPollTime });

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -51,7 +51,7 @@ SiteBuilder.prototype.build = function() {
           buildJekyll(builder) : rsync(builder);
       })
       .then(function() {
-        return syncResults(builder.sync, builder.configHandler);
+        return syncResults(builder);
       });
   };
 
@@ -59,8 +59,14 @@ SiteBuilder.prototype.build = function() {
 };
 
 function rsync(builder) {
-  return builder.commandRunner.run(config.rsync,
-    config.rsyncOpts.concat(['./', builder.configHandler.buildDestination]));
+  var generateRsyncOps = function(previousRsync, buildConfig) {
+    return previousRsync.then(function() {
+      return builder.commandRunner.run(config.rsync,
+        config.rsyncOpts.concat(['./', buildConfig.destination]));
+    });
+  };
+  return builder.configHandler.buildConfigurations().reduce(
+    generateRsyncOps, Promise.resolve());
 }
 
 function buildJekyll(builder) {
@@ -77,13 +83,14 @@ function buildJekyll(builder) {
     .then(cleanup, cleanup);
 }
 
-function syncResults(sync, configHandler) {
-  return sync.sync(configHandler.buildDestination)
-    .then(function() {
-      if (configHandler.internalBuildDestination) {
-        return sync.sync(configHandler.internalBuildDestination);
-      }
+function syncResults(builder) {
+  var generateSyncOps = function(previousSync, buildConfig) {
+    return previousSync.then(function() {
+      return builder.sync.sync(buildConfig.destination);
     });
+  };
+  return builder.configHandler.buildConfigurations().reduce(
+    generateSyncOps, Promise.resolve());
 }
 
 SiteBuilder.launchBuilder = function(info, branch, builderConfig) {

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -94,21 +94,27 @@ SiteBuilder.launchBuilder = function(info, branch, builderConfig) {
 
   finishBuild = function(err) {
     return new Promise(function(resolve, reject) {
-      if (err !== undefined) {
-        logger.error(err);
+      // Provides https://pages.18f.gov/REPO-NAME/build.log as an indicator of
+      // latest status.
+      var newLogPath = path.join(
+        builder.configHandler.buildDestination, 'build.log');
+
+      if (err) {
+        logger.error(err.message ? err.message : err);
         logger.error(builderOpts.repoName + ': build failed');
       } else {
         logger.log(builderOpts.repoName + ': build successful');
       }
 
-      // Provides https://pages.18f.gov/REPO-NAME/build.log as an indicator of
-      // latest status.
-      var newLogPath = path.join(
-        builder.configHandler.buildDestination, 'build.log');
-      fs.rename(buildLog, newLogPath, function(err) {
-        if (err !== null) {
-          console.error('Error moving build log from', buildLog, 'to',
-            newLogPath);
+      fs.rename(buildLog, newLogPath, function(renameErr) {
+        var errMsg;
+
+        if (renameErr) {
+          errMsg = 'Error moving build log: ' + renameErr;
+          console.error(errMsg);
+          if (!err) {
+            reject(errMsg);
+          }
         }
         logger.close(function() {
           return err ? reject(err) : resolve();

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -74,7 +74,7 @@ function buildJekyll(builder) {
     .then(cleanup, cleanup);
 }
 
-SiteBuilder.launchBuilder = function(info, branch, builderConfig, done) {
+SiteBuilder.launchBuilder = function(info, branch, builderConfig) {
   var builderOpts = new Options(info, config, builderConfig),
       commit = info.head_commit,
       buildLog = builderOpts.sitePath + '.log',
@@ -93,26 +93,26 @@ SiteBuilder.launchBuilder = function(info, branch, builderConfig, done) {
   logger.log('sender:', info.sender.login);
 
   finishBuild = function(err) {
-    if (err !== undefined) {
-      logger.error(err);
-      logger.error(builderOpts.repoName + ': build failed');
-    } else {
-      logger.log(builderOpts.repoName + ': build successful');
-    }
-
-    // Provides https://pages.18f.gov/REPO-NAME/build.log as an indicator of
-    // latest status.
-    var newLogPath = path.join(
-      builder.configHandler.buildDestination, 'build.log');
-    fs.rename(buildLog, newLogPath, function(err) {
-      if (err !== null) {
-        console.error('Error moving build log from', buildLog, 'to',
-          newLogPath);
+    return new Promise(function(resolve, reject) {
+      if (err !== undefined) {
+        logger.error(err);
+        logger.error(builderOpts.repoName + ': build failed');
+      } else {
+        logger.log(builderOpts.repoName + ': build successful');
       }
-      logger.close(function() {
-        if (done) {
-          done(err);
+
+      // Provides https://pages.18f.gov/REPO-NAME/build.log as an indicator of
+      // latest status.
+      var newLogPath = path.join(
+        builder.configHandler.buildDestination, 'build.log');
+      fs.rename(buildLog, newLogPath, function(err) {
+        if (err !== null) {
+          console.error('Error moving build log from', buildLog, 'to',
+            newLogPath);
         }
+        logger.close(function() {
+          return err ? reject(err) : resolve();
+        });
       });
     });
   };
@@ -120,7 +120,7 @@ SiteBuilder.launchBuilder = function(info, branch, builderConfig, done) {
     .then(finishBuild, finishBuild);
 };
 
-SiteBuilder.makeBuilderListener = function(webhook, builderConfig, done) {
+SiteBuilder.makeBuilderListener = function(webhook, builderConfig) {
   var org = builderConfig.githubOrg || config.githubOrg,
       branchPattern = builderConfig.branchInUrlPattern || builderConfig.branch,
       branchRegexp,
@@ -132,9 +132,10 @@ SiteBuilder.makeBuilderListener = function(webhook, builderConfig, done) {
     var branch = branchRegexp.exec(info.ref);
 
     if (branch && (info.repository.organization === org)) {
-      SiteBuilder.launchBuilder(info, branch[1], builderConfig, done);
+      return SiteBuilder.launchBuilder(info, branch[1], builderConfig);
     }
   };
   webhook.on('create', handler);
   webhook.on('push', handler);
+  return handler;
 };

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -49,6 +49,9 @@ SiteBuilder.prototype.build = function() {
       .then(function() {
         return builder.configHandler.usesJekyll ?
           buildJekyll(builder) : rsync(builder);
+      })
+      .then(function() {
+        return syncResults(builder.sync, builder.configHandler);
       });
   };
 
@@ -72,6 +75,15 @@ function buildJekyll(builder) {
         { bundler: builder.configHandler.usesBundler });
     })
     .then(cleanup, cleanup);
+}
+
+function syncResults(sync, configHandler) {
+  return sync.sync(configHandler.buildDestination)
+    .then(function() {
+      if (configHandler.internalBuildDestination) {
+        return sync.sync(configHandler.internalBuildDestination);
+      }
+    });
 }
 
 SiteBuilder.launchBuilder = function(info, branch, builderConfig) {

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -59,14 +59,18 @@ SiteBuilder.prototype.build = function() {
 };
 
 function rsync(builder) {
-  var generateRsyncOps = function(previousRsync, buildConfig) {
-    return previousRsync.then(function() {
-      return builder.commandRunner.run(config.rsync,
-        config.rsyncOpts.concat(['./', buildConfig.destination]));
-    });
-  };
   return builder.configHandler.buildConfigurations().reduce(
-    generateRsyncOps, Promise.resolve());
+    function(previousRsync, buildConfig) {
+      return generateRsyncOp(builder, previousRsync, buildConfig);
+    },
+    Promise.resolve());
+}
+
+function generateRsyncOp(builder, previousRsync, buildConfig) {
+  return previousRsync.then(function() {
+    return builder.commandRunner.run(config.rsync,
+      config.rsyncOpts.concat(['./', buildConfig.destination]));
+  });
 }
 
 function buildJekyll(builder) {
@@ -84,13 +88,17 @@ function buildJekyll(builder) {
 }
 
 function syncResults(builder) {
-  var generateSyncOps = function(previousSync, buildConfig) {
-    return previousSync.then(function() {
-      return builder.sync.sync(buildConfig.destination);
-    });
-  };
   return builder.configHandler.buildConfigurations().reduce(
-    generateSyncOps, Promise.resolve());
+    function(previousSync, buildConfig) {
+      return generateSyncOp(builder, previousSync, buildConfig);
+    },
+    Promise.resolve());
+}
+
+function generateSyncOp(builder, previousSync, buildConfig) {
+  return previousSync.then(function() {
+    return builder.sync.sync(buildConfig.destination);
+  });
 }
 
 SiteBuilder.launchBuilder = function(info, branch, builderConfig) {

--- a/lib/sync.js
+++ b/lib/sync.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var path = require('path');
+
+module.exports = Sync;
+
+function Sync(config, commandRunner, logger) {
+  this.home = config.home;
+  this.s3 = config.s3;
+  this.commandRunner = commandRunner;
+  this.logger = logger;
+}
+
+Sync.prototype.sync = function(buildDestination) {
+  var homePrefix = path.join(this.home, path.sep),
+      s3Path;
+
+  if (buildDestination.substr(0, homePrefix.length) !== homePrefix) {
+    throw new Error('invalid build destination ' + buildDestination +
+      '; should be a subdirectory of ' + this.home);
+  }
+
+  if (!this.s3) {
+    return Promise.resolve();
+  }
+
+  s3Path = this.s3.bucket +
+    buildDestination.substr(this.home.length).replace(/\\/g, '/');
+
+  this.logger.log('syncing to', s3Path);
+  return this.commandRunner.run(this.s3.awscli,
+    ['s3', 'sync', buildDestination, s3Path, '--delete'],
+    null, 's3 sync failed for');
+};

--- a/pages-config.json
+++ b/pages-config.json
@@ -8,6 +8,10 @@
   "rsyncOpts":        [
     "-vaxp", "--delete", "--ignore-errors", "--exclude=.[A-Za-z0-9]*"
   ],
+  "s3": {
+    "awscli": "/usr/local/18f/pyenv/shims/aws",
+    "bucket":  "s3://18f-pages"
+  },
   "payloadLimit":     1048576,
   "githubOrg":        "18F",
   "pagesConfig":      "_config_18f_pages.yml",

--- a/test/config-handler-test.js
+++ b/test/config-handler-test.js
@@ -3,6 +3,7 @@
 var ConfigHandler = require('../lib/config-handler');
 var RepositoryFileHandler = require('../lib/repository-file-handler');
 var BuildLogger = require('../lib/build-logger');
+var Options = require('../lib/options');
 var pagesConfig = require('../pages-config.json');
 var path = require('path');
 var sinon = require('sinon');
@@ -17,18 +18,25 @@ describe('ConfigHandler', function() {
   var config, opts, handler, fileHandler, logger;
 
   before(function() {
-    config = JSON.parse(JSON.stringify(pagesConfig));
-    opts = {
-      pagesConfig: config.pagesConfig,
-      pagesYaml: config.pagesYaml,
-      repoName: 'repo_name',
-      destDir: 'dest_dir',
-      internalDestDir: 'internal_dest_dir',
-      assetRoot: '/guides-template',
-      branchInUrlPattern: ''
+    var payload, builderConfig;
+
+    payload = {
+      repository: {
+        name: 'repo_name'
+      },
+      ref: 'refs/heads/18f-pages'
     };
-    opts.sitePath = path.join('some/test/dir', opts.repoName);
-    fileHandler = new RepositoryFileHandler(opts);
+    config = JSON.parse(JSON.stringify(pagesConfig));
+    config.home = '/usr/local/18f/pages';
+    config.assetRoot = '/guides-template';
+    builderConfig = {
+      'branch': '18f-pages',
+      'repositoryDir': 'repo_dir',
+      'generatedSiteDir': 'dest_dir',
+      'internalSiteDir': 'internal_dest_dir'
+    };
+    opts = new Options(payload, config, builderConfig);
+    fileHandler = new RepositoryFileHandler(opts.sitePath);
     logger = new BuildLogger();
   });
 
@@ -70,7 +78,7 @@ describe('ConfigHandler', function() {
       return handler.init().should.be.fulfilled
         .then(function() {
           handler.buildConfigurations().should.eql([
-            { destination: path.join('dest_dir/repo_name'),
+            { destination: path.join(config.home, 'dest_dir/repo_name'),
               configurations: '_config.yml,' + config.pagesConfig
             }
           ]);
@@ -105,11 +113,12 @@ describe('ConfigHandler', function() {
       return handler.init().should.be.fulfilled
         .then(function() {
           handler.buildConfigurations().should.eql([
-            { destination: path.join('internal_dest_dir/repo_name'),
+            { destination: path.join(
+                config.home, 'internal_dest_dir/repo_name'),
               configurations: '_config.yml,_config_internal.yml,' +
                 config.pagesConfig
             },
-            { destination: path.join('dest_dir/repo_name'),
+            { destination: path.join(config.home, 'dest_dir/repo_name'),
               configurations: '_config.yml,' + config.pagesConfig
             }
           ]);
@@ -124,11 +133,12 @@ describe('ConfigHandler', function() {
       return handler.init().should.be.fulfilled
         .then(function() {
           handler.buildConfigurations().should.eql([
-            { destination: path.join('internal_dest_dir/repo_name'),
+            { destination: path.join(
+                config.home, 'internal_dest_dir/repo_name'),
               configurations: '_config.yml,_config_internal.yml,' +
                 config.pagesConfig
             },
-            { destination: path.join('dest_dir/repo_name'),
+            { destination: path.join(config.home, 'dest_dir/repo_name'),
               configurations: '_config.yml,_config_external.yml,' +
                 config.pagesConfig
             }
@@ -148,11 +158,12 @@ describe('ConfigHandler', function() {
       return handler.init().should.be.fulfilled
         .then(function() {
           handler.buildConfigurations().should.eql([
-            { destination: path.join('internal_dest_dir/repo_name/v0.9.0'),
+            { destination: path.join(config.home,
+                'internal_dest_dir/repo_name/v0.9.0'),
               configurations: '_config.yml,_config_internal.yml,' +
                 config.pagesConfig
             },
-            { destination: path.join('dest_dir/repo_name/v0.9.0'),
+            { destination: path.join(config.home, 'dest_dir/repo_name/v0.9.0'),
               configurations: '_config.yml,' + config.pagesConfig
             }
           ]);
@@ -208,7 +219,8 @@ describe('ConfigHandler', function() {
           handler.internalBuildDestination.should.eql(
             path.join(handler.internalDestDir, '/new-baseurl'));
           handler.buildConfigurations().should.eql([
-            { destination: path.join('dest_dir/new-baseurl/v0.9.0'),
+            { destination: path.join(
+              config.home, 'dest_dir/new-baseurl/v0.9.0'),
               configurations: '_config.yml,' + config.pagesConfig
             }
           ]);
@@ -242,7 +254,7 @@ describe('ConfigHandler', function() {
           handler.internalBuildDestination.should.eql(
             path.join(handler.internalDestDir, handler.repoName));
           handler.buildConfigurations().should.eql([
-            { destination: path.join('dest_dir', handler.repoName),
+            { destination: path.join(config.home, 'dest_dir', handler.repoName),
               configurations: '_config.yml,' + config.pagesConfig
             }
           ]);
@@ -269,7 +281,7 @@ describe('ConfigHandler', function() {
     });
 
     it('should not detect YAML file presence if not configured', function() {
-      // This can happen if the pages-config.json file does not have 
+      // This can happen if the pages-config.json file does not have
       // a pagesYaml property defined.
       fileHandler.exists.withArgs(undefined).throws();
       handler.pagesYaml = undefined;
@@ -288,50 +300,54 @@ describe('ConfigHandler', function() {
   describe('parseDestinationFromConfigData', function() {
     it('should keep the default destination if undefined', function() {
       handler.parseDestinationFromConfigData('');
-      handler.buildDestination.should.equal(path.join('dest_dir/repo_name'));
+      handler.buildDestination.should.equal(
+        path.join(config.home, 'dest_dir/repo_name'));
     });
 
     it('should keep the default destination if empty', function() {
       handler.parseDestinationFromConfigData('baseurl:\n');
-      handler.buildDestination.should.equal(path.join('dest_dir/repo_name'));
+      handler.buildDestination.should.equal(
+        path.join(config.home, 'dest_dir/repo_name'));
     });
 
     it('should keep the default destination if empty with spaces', function() {
       handler.parseDestinationFromConfigData('baseurl:   \n');
-      handler.buildDestination.should.equal(path.join('dest_dir/repo_name'));
+      handler.buildDestination.should.equal(
+        path.join(config.home, 'dest_dir/repo_name'));
     });
 
     it('should keep the default destination if set to root path', function() {
       handler.parseDestinationFromConfigData('baseurl: /\n');
-      handler.buildDestination.should.equal(path.join('dest_dir/repo_name'));
+      handler.buildDestination.should.equal(
+        path.join(config.home, 'dest_dir/repo_name'));
     });
 
     it('should set the destination from config data baseurl', function() {
       handler.parseDestinationFromConfigData('baseurl: /new-destination\n');
       handler.buildDestination.should.equal(
-        path.join('dest_dir/new-destination'));
+        path.join(config.home, 'dest_dir/new-destination'));
     });
 
     it('should set the internal destination from config data', function() {
-      handler.internalDestDir = 'internal_dest_dir';
+      handler.internalDestDir = path.join(config.home, 'internal_dest_dir');
       handler.parseDestinationFromConfigData('baseurl: /new-destination\n');
       handler.buildDestination.should.equal(
-        path.join('dest_dir/new-destination'));
+        path.join(config.home, 'dest_dir/new-destination'));
       handler.internalBuildDestination.should.equal(
-        path.join('internal_dest_dir/new-destination'));
+        path.join(config.home, 'internal_dest_dir/new-destination'));
     });
 
     it('should parse baseurl if no leading space', function() {
       handler.parseDestinationFromConfigData('baseurl:/new-destination\n');
       handler.buildDestination.should.equal(
-        path.join('dest_dir/new-destination'));
+        path.join(config.home, 'dest_dir/new-destination'));
     });
 
     it('should trim all spaces around baseurl', function() {
       handler.parseDestinationFromConfigData(
         'baseurl:   /new-destination   \n');
       handler.buildDestination.should.equal(
-        path.join('dest_dir/new-destination'));
+        path.join(config.home, 'dest_dir/new-destination'));
     });
   });
 

--- a/test/files-helper.js
+++ b/test/files-helper.js
@@ -15,38 +15,26 @@ FilesHelper.prototype.init = function(config) {
 
   return new Promise(function(resolve, reject) {
     temp.mkdir(scriptName + '-test-files-', function(err, tempDir) {
-      var testRepoDir = path.resolve(tempDir, 'site_builder_test'),
-          lockDir = path.resolve(tempDir, 'site_builder_test_lock_dir');
-
       if (err) {
         return reject(err);
       }
-
-      fs.mkdir(lockDir, '0700', function(err) {
-        if (err) {
-          return reject(err);
-        }
-        initHelper(helper, config, tempDir, testRepoDir, lockDir);
-        resolve();
-      });
+      helper.tempDir = tempDir;
+      config.home = tempDir;
+      initHelper(helper, config);
+      resolve();
     });
   });
 };
 
-function initHelper(helper, config, tempDir, testRepoDir, lockDir) {
-  helper.dirs = {
-    testRepoDir: testRepoDir,
-    lockDir: lockDir,
-    tempDir: tempDir
-  };
+function initHelper(helper, config) {
+  helper.dirs = [];
 
   helper.files = {
-    gemfile: path.resolve(testRepoDir, 'Gemfile'),
-    pagesConfig: path.resolve(testRepoDir, config.pagesConfig),
-    configYml: path.resolve(testRepoDir, '_config.yml'),
-    internalConfig: path.resolve(testRepoDir, '_config_internal.yml'),
-    externalConfig: path.resolve(testRepoDir, '_config_external.yml'),
-    lockfilePath: path.resolve(lockDir, '.update-lock-repo_name')
+    gemfile: 'Gemfile',
+    pagesConfig: config.pagesConfig,
+    configYml: '_config.yml',
+    internalConfig: '_config_internal.yml',
+    externalConfig: '_config_external.yml'
   };
 
   helper.filesToDelete = [];
@@ -61,82 +49,58 @@ FilesHelper.prototype.afterEach = function() {
     return helper.files[key];
   }));
 
-  return removeItems(files, 'unlink')
+  return removeItems(this.tempDir, files, 'unlink')
     .then(function() {
-      return helper.removeDir(helper.dirs.testRepoDir);
+      return removeItems(helper.tempDir, helper.dirs.reverse(), 'rmdir');
     });
 };
 
 FilesHelper.prototype.after = function() {
-  return removeItems([this.dirs.lockDir, this.dirs.tempDir], 'rmdir');
+  return removeItems(this.tempDir, [''], 'rmdir');
 };
 
-FilesHelper.prototype.createRepoDir = function() {
+FilesHelper.prototype.createDir = function(dirName) {
   var helper = this;
 
   return new Promise(function(resolve, reject) {
-    fs.mkdir(helper.dirs.testRepoDir, '0700', function(err) {
+    fs.mkdir(path.join(helper.tempDir, dirName), '0700', function(err) {
       if (err) {
         return reject(err);
       }
-      fs.writeFile(helper.files.configYml, '', function(err) {
-        if (err) {
-          return reject(err);
-        }
-        resolve();
-      });
+      helper.dirs.push(dirName);
+      resolve();
     });
   });
 };
 
-FilesHelper.prototype.createRepoWithFiles = function(nameToContents) {
-  var helper = this,
-      writeFile;
-
-  this.filesToDelete = Object.keys(nameToContents);
-  writeFile = function(filename) {
-    return new Promise(function(resolve, reject) {
-      fs.writeFile(filename, nameToContents[filename], function(err) {
-        if (err) {
-          return reject(err);
-        }
-        resolve();
-      });
-    });
-  };
-
-  return this.createRepoDir()
-    .then(function() {
-      return Promise.all(helper.filesToDelete.map(writeFile));
-    });
-};
-
 FilesHelper.prototype.removeFile = function(filename) {
-  return removeItem(filename, 'unlink');
+  return removeItem(this.tempDir, filename, 'unlink');
 };
 
 FilesHelper.prototype.removeDir = function(dirname) {
-  return removeItem(dirname, 'rmdir');
+  return removeItem(this.tempDir, dirname, 'rmdir');
 };
 
-function removeItems(items, operation) {
+function removeItems(parentDir, items, operation) {
   var remover;
 
   remover = function(result, item) {
     return result.then(function() {
-      return removeItem(item, operation);
+      return removeItem(parentDir, item, operation);
     });
   };
   return items.reduce(remover, Promise.resolve());
 }
 
-function removeItem(name, operation) {
+function removeItem(parentDir, name, operation) {
+  var itemPath = path.join(parentDir, name);
+
   return new Promise(function(resolve, reject) {
-    fs.exists(name, function(exists) {
+    fs.exists(itemPath, function(exists) {
       if (!exists) {
         return resolve();
       }
-      fs[operation](name, function(err) {
+      fs[operation](itemPath, function(err) {
         if (err) {
           return reject(err);
         }

--- a/test/files-helper.js
+++ b/test/files-helper.js
@@ -10,8 +10,11 @@ module.exports = FilesHelper;
 function FilesHelper() {
 }
 
-FilesHelper.prototype.init = function(config) {
+FilesHelper.prototype.init = function() {
   var helper = this;
+
+  this.dirs = [];
+  this.files = [];
 
   return new Promise(function(resolve, reject) {
     temp.mkdir(scriptName + '-test-files-', function(err, tempDir) {
@@ -19,37 +22,15 @@ FilesHelper.prototype.init = function(config) {
         return reject(err);
       }
       helper.tempDir = tempDir;
-      config.home = tempDir;
-      initHelper(helper, config);
       resolve();
     });
   });
 };
 
-function initHelper(helper, config) {
-  helper.dirs = [];
-
-  helper.files = {
-    gemfile: 'Gemfile',
-    pagesConfig: config.pagesConfig,
-    configYml: '_config.yml',
-    internalConfig: '_config_internal.yml',
-    externalConfig: '_config_external.yml'
-  };
-
-  helper.filesToDelete = [];
-}
-
 FilesHelper.prototype.afterEach = function() {
-  var helper = this,
-      files = helper.filesToDelete.slice();
+  var helper = this;
 
-  helper.filesToDelete = [];
-  files = files.concat(Object.keys(helper.files).map(function(key) {
-    return helper.files[key];
-  }));
-
-  return removeItems(this.tempDir, files, 'unlink')
+  return removeItems(this.tempDir, this.files, 'unlink')
     .then(function() {
       return removeItems(helper.tempDir, helper.dirs.reverse(), 'rmdir');
     });
@@ -71,14 +52,6 @@ FilesHelper.prototype.createDir = function(dirName) {
       resolve();
     });
   });
-};
-
-FilesHelper.prototype.removeFile = function(filename) {
-  return removeItem(this.tempDir, filename, 'unlink');
-};
-
-FilesHelper.prototype.removeDir = function(dirname) {
-  return removeItem(this.tempDir, dirname, 'rmdir');
 };
 
 function removeItems(parentDir, items, operation) {

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -84,7 +84,7 @@ describe('SiteBuilder', function() {
     beforeEach(function() {
       builder = makeBuilder();
       buildConfigs = [{
-        destination: 'dest_dir',
+        destination: path.join(config.home, 'dest_dir/repo_name'),
         configurations: '_config.yml,' + config.pagesConfig
       }];
 

--- a/test/sync-test.js
+++ b/test/sync-test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var Sync = require('../lib/sync');
+var pagesConfig = require('../pages-config.json');
+var path = require('path');
+var sinon = require('sinon');
+var chai = require('chai');
+var chaiAsPromised = require('chai-as-promised');
+var expect = chai.expect;
+
+chai.should();
+chai.use(chaiAsPromised);
+
+describe('Sync', function() {
+  var sync,
+      config,
+      fakeRunner = {},
+      fakeLogger = {},
+      buildDestination = path.join(pagesConfig.home, 'dest_dir/repo_name');
+
+  beforeEach(function() {
+    config = JSON.parse(JSON.stringify(pagesConfig));
+    config.s3 = {
+      awscli: 'aws',
+      bucket: 's3://18f-pages'
+    };
+    fakeRunner.run = sinon.stub();
+    fakeLogger.log = sinon.stub();
+    sync = new Sync(config, fakeRunner, fakeLogger);
+  });
+
+  it('should throw if the build destination is invalid', function() {
+    expect(function() { sync.sync('/foo'); })
+      .to.throw('invalid build destination /foo; ' +
+        'should be a subdirectory of ' + config.home);
+    fakeRunner.run.called.should.be.false;
+    fakeLogger.log.called.should.be.false;
+  });
+
+  it('should skip the sync if not configured', function() {
+    delete sync.s3;
+    return sync.sync(buildDestination).should.be.fulfilled.then(function() {
+      fakeRunner.run.called.should.be.false;
+      fakeLogger.log.called.should.be.false;
+    });
+  });
+
+  it('should invoke the aws s3 sync tool', function() {
+    var s3Path = config.s3.bucket + '/dest_dir/repo_name';
+
+    fakeRunner.run.returns(Promise.resolve());
+    return sync.sync(buildDestination).should.be.fulfilled.then(function() {
+      fakeRunner.run.args.should.eql([
+        [config.s3.awscli,
+         ['s3', 'sync', buildDestination, s3Path, '--delete'],
+         null,
+         's3 sync failed for'
+        ]
+      ]);
+      fakeLogger.log.args.should.eql([['syncing to', s3Path]]);
+    });
+  });
+
+  it('should report an error from the aws s3 sync tool', function() {
+    fakeRunner.run.returns(Promise.reject('test failure'));
+    return sync.sync(buildDestination)
+      .should.be.rejectedWith('test failure');
+  });
+});


### PR DESCRIPTION
This will enable the `pages` container of the [18F/knowledge-sharing-toolkit](https://github.com/18F/knowledge-sharing-toolkit/) to download all existing sites upon startup, allowing the service to be run on different machine instances.

This PR as is contains a lot of test cleanup, and the initial implementation of the `Sync` class can arguably occupy another PR. If this PR is too big, I'm happy to kick it apart.

cc: @msecret @DavidEBest @rogeruiz @catherinedevlin @afeld 
