### PR TITLE
Strip trailing whitespace from command output

### DIFF
--- a/lib/command-runner.js
+++ b/lib/command-runner.js
@@ -24,12 +24,12 @@ function doRun(runner, path, args, opts, message) {
 
     command.stdout.setEncoding('utf8');
     command.stdout.on('data', function(data) {
-      runner.logger.log(data);
+      runner.logger.log(data.trimRight());
     });
 
     command.stderr.setEncoding('utf8');
     command.stderr.on('data', function(data) {
-      runner.logger.error(data);
+      runner.logger.error(data.trimRight());
     });
 
     command.on('close', function(code) {

--- a/test/command-runner-test.js
+++ b/test/command-runner-test.js
@@ -21,7 +21,7 @@ describe('CommandRunner', function() {
   it('should pass stdout to the logger and exit normally', function() {
     return runner.run('node', [TEST_COMMAND, 'foo', 'bar', 'baz'])
       .should.be.fulfilled.then(function() {
-        fakeLogger.log.args.should.eql([['foo bar baz\n']]);
+        fakeLogger.log.args.should.eql([['foo bar baz']]);
         sinon.assert.notCalled(fakeLogger.error);
       });
   });
@@ -33,7 +33,7 @@ describe('CommandRunner', function() {
       .then(function() {
         sinon.assert.notCalled(fakeLogger.log);
         fakeLogger.error.args.should.eql(
-          [['no arguments passed on the command line\n']]);
+          [['no arguments passed on the command line']]);
       });
   });
 });


### PR DESCRIPTION
This is a tiny, annoying little thing; going to merge myself and cut v0.3.1.
