### PR TITLE
Ensure branch matches are exact, not just prefix

### DIFF
--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -161,7 +161,7 @@ SiteBuilder.makeBuilderListener = function(webhook, builderConfig) {
       branchRegexp,
       handler;
 
-  branchRegexp = new RegExp('refs/heads/(' + branchPattern + ')');
+  branchRegexp = new RegExp('refs/heads/(' + branchPattern + ')$');
 
   handler = function(info) {
     var branch = branchRegexp.exec(info.ref);

--- a/test/site-builder-test.js
+++ b/test/site-builder-test.js
@@ -282,6 +282,26 @@ describe('SiteBuilder', function() {
       expect(webhook.on.args[1][1]).to.be.handler;
     });
 
+    it('should match the branch exactly, not just a prefix', function() {
+      var handler = SiteBuilder.makeBuilderListener(webhook, builderConfig),
+          payload = JSON.parse(JSON.stringify(incomingPayload)),
+          builder;
+
+      payload.ref = 'refs/heads/18f-pages-internal';
+      captureLogs();
+      builder = handler(payload);
+
+      if (builder) {
+        return builder.then(function() {
+          return Promise.reject(new Error('the handler should not have ' +
+            'matched a longer branch name that contains the target branch ' +
+            'name as a prefix'));
+        })
+        .catch(restoreLogs);
+      }
+      return restoreLogs();
+    });
+
     it('should create a builder that builds the site', function() {
       var handler = SiteBuilder.makeBuilderListener(webhook, builderConfig);
 


### PR DESCRIPTION
Closes #46. Payloads from 18f-pages-internal were also matched by the 18f-pages webhook listener. Hence, though the content on pages-internal.18f.gov vs. pages.18f.gov was correct, the pages.18f.gov version was getting built every time the pages-internal.18f.gov version was getting built, and the build.log files were identical.

cc: @afeld @DavidEBest 
