### PR TITLE
Migrate log with streams instead of fs.rename

### DIFF
--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -111,7 +111,8 @@ SiteBuilder.launchBuilder = function(info, branch, builderConfig) {
       builder = new SiteBuilder(
         branch,
         new ComponentFactory(config, builderOpts, branch, logger)),
-      finishBuild;
+      finishBuild,
+      migrateLog;
 
   logger.log(info.repository.full_name + ':',
     'starting build at commit', commit.id);
@@ -125,35 +126,58 @@ SiteBuilder.launchBuilder = function(info, branch, builderConfig) {
     return new Promise(function(resolve, reject) {
       // Provides https://pages.18f.gov/REPO-NAME/build.log as an indicator of
       // latest status.
-      var newLogPath = path.join(
-        builder.configHandler.buildDestination, 'build.log');
-
       if (err) {
         logger.error(err.message ? err.message : err);
         logger.error(builderOpts.repoName + ': build failed');
       } else {
         logger.log(builderOpts.repoName + ': build successful');
       }
-
-      fs.rename(buildLog, newLogPath, function(renameErr) {
-        var errMsg;
-
-        if (renameErr) {
-          errMsg = 'Error moving build log: ' + renameErr;
-          console.error(errMsg);
-          if (!err) {
-            reject(errMsg);
-          }
-        }
-        logger.close(function() {
-          return err ? reject(err) : resolve();
-        });
+      logger.close(function() {
+        return err ? reject(err) : resolve();
       });
     });
   };
+
+  migrateLog = function(err) {
+    var newLogPath = path.join(
+          builder.configHandler.buildDestination, 'build.log');
+
+    return copyLog(buildLog, newLogPath)
+      .then(function() {
+        return removeLog(buildLog);
+      })
+      .catch(function(err) {
+        console.error('Error moving build log: ' + (err.message || err));
+        return Promise.reject(err);
+      })
+      .then(function() {
+        return err ? Promise.reject(err) : Promise.resolve();
+      });
+  };
   return builder.build()
-    .then(finishBuild, finishBuild);
+    .then(finishBuild, finishBuild)
+    .then(migrateLog, migrateLog);
 };
+
+function copyLog(sourceLog, targetLog) {
+  return new Promise(function(resolve, reject) {
+    var sourceStream = fs.createReadStream(sourceLog),
+        targetStream = fs.createWriteStream(targetLog);
+
+    sourceStream.on('error', reject);
+    targetStream.on('error', reject);
+    targetStream.on('close', resolve);
+    sourceStream.pipe(targetStream);
+  });
+}
+
+function removeLog(sourceLog) {
+  return new Promise(function(resolve, reject) {
+    fs.unlink(sourceLog, function(err) {
+      return err ? reject(err) : resolve();
+    });
+  });
+}
 
 SiteBuilder.makeBuilderListener = function(webhook, builderConfig) {
   var org = builderConfig.githubOrg || config.githubOrg,

--- a/lib/site-builder.js
+++ b/lib/site-builder.js
@@ -159,6 +159,16 @@ SiteBuilder.launchBuilder = function(info, branch, builderConfig) {
     .then(migrateLog, migrateLog);
 };
 
+// In the Dockerized 18F/knowledge-sharing-toolkit environment, the git
+// repositories live on one Docker volume (pages/repos), and the generated
+// sites live on another (pages/sites). This server orignally used
+// fs.rename(), which failed in this environment with the error:
+//
+//   Error moving build log: Error: EXDEV: cross-device link not permitted,
+//   rename '/usr/local/18f/pages/repos/pages-internal.18f.gov/hub.log' ->
+//   '/usr/local/18f/pages/sites/pages-internal.18f.gov/hub/build.log'
+//
+// Copying and manually removing the original log resolves this issue.
 function copyLog(sourceLog, targetLog) {
   return new Promise(function(resolve, reject) {
     var sourceStream = fs.createReadStream(sourceLog),


### PR DESCRIPTION
Discovered during Dockerization in 18F/knowledge-sharing-toolkit that fs.rename doesn't work when trying to move the log file from one volume to another, specifically from pages/repos to pages/sites.

All tests continue to pass. Ideally I'd like to set up two different volumes to test with, but not sure the benefit is worth the complexity (nor would Travis let me get away with that, I imagine).

cc: @afeld @catherinedevlin @jbarnicle @ertzeid 
