### PR TITLE
Better CommandRunner error reporting, force piped stdio

### DIFF
--- a/lib/command-runner.js
+++ b/lib/command-runner.js
@@ -18,9 +18,15 @@ function doRun(runner, path, args, opts, message) {
   return new Promise(function(resolve, reject) {
     var command,
         options = opts || {cwd: runner.sitePath},
-        msg = message || 'rebuild failed for';
+        msg = message || 'rebuild failed for',
+        error;
 
     command = childProcess.spawn(path, args, options);
+    command.on('error', function(err) {
+      error = err;
+      reject('Error: ' + msg + ' ' + runner.repoName + ' due to failed ' +
+        'command: ' + path + ' ' + args.join(' ') + ': ' + err.message);
+    });
 
     command.stdout.setEncoding('utf8');
     command.stdout.on('data', function(data) {
@@ -33,6 +39,9 @@ function doRun(runner, path, args, opts, message) {
     });
 
     command.on('close', function(code) {
+      if (error) {
+        return;
+      }
       if (code !== 0) {
         reject('Error: ' + msg + ' ' + runner.repoName + ' with exit code ' +
           code + ' from command: ' + path + ' ' + args.join(' '));

--- a/lib/command-runner.js
+++ b/lib/command-runner.js
@@ -21,6 +21,12 @@ function doRun(runner, path, args, opts, message) {
         msg = message || 'rebuild failed for',
         error;
 
+    if (options.stdio) {
+      runner.logger.error('CommandRunner ignoring stdio option value: '
+        + options.stdio);
+      delete options.stdio;
+    }
+
     command = childProcess.spawn(path, args, options);
     command.on('error', function(err) {
       error = err;

--- a/lib/git-runner.js
+++ b/lib/git-runner.js
@@ -50,7 +50,7 @@ function cloneRepo(gitRunner, branch) {
   var cloneAddr = 'git@github.com:' + gitRunner.githubOrg + '/' +
         gitRunner.commandRunner.repoName + '.git',
       cloneArgs = ['clone', cloneAddr, '--branch', branch],
-      cloneOpts = {cwd: gitRunner.repoDir, stdio: 'inherit'},
+      cloneOpts = { cwd: gitRunner.repoDir },
       errMsg = 'failed to clone';
 
   gitRunner.logger.log('cloning', gitRunner.commandRunner.repoName,

--- a/test/command-runner-test.js
+++ b/test/command-runner-test.js
@@ -1,11 +1,12 @@
 'use strict';
 
 var CommandRunner = require('../lib/command-runner');
+var path = require('path');
 var sinon = require('sinon');
 var chai = require('chai');
 var chaiAsPromised = require('chai-as-promised');
 
-var TEST_COMMAND = 'fake-command.js';
+var TEST_COMMAND = path.join(__dirname, 'fake-command.js');
 
 chai.should();
 chai.use(chaiAsPromised);

--- a/test/command-runner-test.js
+++ b/test/command-runner-test.js
@@ -38,6 +38,15 @@ describe('CommandRunner', function() {
       });
   });
 
+  it('should log and ignore the stdio option', function() {
+    return runner.run('node', [TEST_COMMAND, 'foobar'], { stdio: 'inherit' })
+      .should.be.fulfilled.then(function() {
+        fakeLogger.log.args.should.eql([['foobar']]);
+        fakeLogger.error.args.should.eql(
+          [['CommandRunner ignoring stdio option value: inherit']]);
+      });
+  });
+
   it('should log a proper error if the command fails to spawn', function() {
     return runner.run('bogus-node', ['nonexistent', 'test'])
       .should.be.rejectedWith('Error: rebuild failed for pages-server due ' +

--- a/test/command-runner-test.js
+++ b/test/command-runner-test.js
@@ -36,4 +36,14 @@ describe('CommandRunner', function() {
           [['no arguments passed on the command line']]);
       });
   });
+
+  it('should log a proper error if the command fails to spawn', function() {
+    return runner.run('bogus-node', ['nonexistent', 'test'])
+      .should.be.rejectedWith('Error: rebuild failed for pages-server due ' +
+        'to failed command: bogus-node nonexistent test: ')
+      .then(function() {
+        sinon.assert.notCalled(fakeLogger.log);
+        sinon.assert.notCalled(fakeLogger.error);
+      });
+  });
 });

--- a/test/git-runner-test.js
+++ b/test/git-runner-test.js
@@ -88,7 +88,7 @@ describe('GitRunner', function() {
             [ 'clone', 'git@github.com:18F/repo_name.git',
               '--branch', '18f-pages'
             ],
-            { cwd: opts.repoDir, stdio: 'inherit' },
+            { cwd: opts.repoDir },
             'failed to clone'
           ]
         ]);


### PR DESCRIPTION
Since CommandRunner expects to pipe output from the spawned command, `stdio: 'inherit'` causes command.stdout and command.stderr to be null, which in turn causes command.stdout.setEncoding to fail. Removing the `delete options.stdio` line from doRun will reproduce the error from the build.log reported in 18F/pages#58:

```
18F/pages: starting build at commit 348bbf4a5bbbd961cb822eb6b6fb6e94507dac96
description: Merge pull request #58 from 18F/homepage

Reorganize homepage in a more user-centered way
timestamp: 2016-03-18T14:10:41-04:00
committer: melody.kramer@gsa.gov
pusher: melodykramer melody.kramer@gsa.gov
sender: melodykramer
cloning pages into /usr/local/18f/pages/repos/pages.18f.gov/pages
Cannot read property 'setEncoding' of null
pages: build failed
```

See also: https://nodejs.org/api/child_process.html#child_process_options_stdio

Also adds more robust error reporting to make `spawn` failures more explicit in general.

cc: @jbarnicle @afeld @catherinedevlin
